### PR TITLE
Make peerinfo the same for manual and auto peers

### DIFF
--- a/pkg/peering/peering.go
+++ b/pkg/peering/peering.go
@@ -189,7 +189,7 @@ func (m *Manager) Whitelist(ips []string, port uint16, autopeeringPeer ...*autop
 		if len(autopeeringPeer) > 0 {
 			m.whitelist[id] = autopeeringPeer[0]
 		} else {
-			m.whitelist[id] = nil
+			m.whitelist[id] = "none"
 		}
 		m.BlacklistRemove(ip)
 	}
@@ -237,6 +237,7 @@ func (m *Manager) PeerInfos() []*peer.Info {
 		addrStr := fmt.Sprintf("%s:%d", originAddr.Addr, originAddr.Port)
 		info := &peer.Info{
 			Address:        addrStr,
+			Port:           originAddr.Port,
 			Domain:         originAddr.Addr,
 			DomainWithPort: addrStr,
 			Alias:          originAddr.Alias,
@@ -244,7 +245,7 @@ func (m *Manager) PeerInfos() []*peer.Info {
 			Connected:      false,
 			PreferIPv6:     originAddr.PreferIPv6,
 		}
-		if reconnectInfo.Autopeering != nil {
+		if reconnectInfo.Autopeering != "none" {
 			info.AutopeeringID = reconnectInfo.Autopeering.ID().String()
 		}
 		infos = append(infos, info)


### PR DESCRIPTION
The webAPI call getNeighbors should always receive the same number of attributes

<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to this repository, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up to smaller PRs. This will help getting it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split to several PRs!!!!!
-->

# Description
The webAPI call getNeighbors should always return the same number of attributes for manual and auto peers, either connected or unconnected. 

# Fix
For manual peers the autopeeringID is set to none, for unconnected peers the port is added and for autopeers the alias is set to none.

## Type of change
- [x] Enhancement (non-breaking change which adds functionality)

# How Has This Been Tested?
Tested on my own Hornet node, version 0.4.0-rc10-7511e71

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my code extensively
- [x] I have selected the `develop` branch as the target branch
