### PR TITLE
Info always same number of attributes

### DIFF
--- a/pkg/peering/peer/peer.go
+++ b/pkg/peering/peer/peer.go
@@ -219,8 +219,8 @@ type Metrics struct {
 type Info struct {
 	Peer                           *Peer  `json:"-"`
 	Address                        string `json:"address"`
-	Port                           uint16 `json:"port,omitempty"`
-	Domain                         string `json:"domain,omitempty"`
+	Port                           uint16 `json:"port"`
+	Domain                         string `json:"domain"`
 	DomainWithPort                 string `json:"-"`
 	Alias                          string `json:"alias,omitempty"`
 	PreferIPv6                     bool   `json:"-"`
@@ -240,5 +240,5 @@ type Info struct {
 	NumberOfDroppedSentPackets     uint32 `json:"numberOfDroppedSentPackets"`
 	ConnectionType                 string `json:"connectionType"`
 	Connected                      bool   `json:"connected"`
-	AutopeeringID                  string `json:"autopeeringId,omitempty"`
+	AutopeeringID                  string `json:"autopeeringId"`
 }

--- a/pkg/peering/peering.go
+++ b/pkg/peering/peering.go
@@ -237,6 +237,7 @@ func (m *Manager) PeerInfos() []*peer.Info {
 		addrStr := fmt.Sprintf("%s:%d", originAddr.Addr, originAddr.Port)
 		info := &peer.Info{
 			Address:        addrStr,
+			Port:           originAddr.Port,
 			Domain:         originAddr.Addr,
 			DomainWithPort: addrStr,
 			Alias:          originAddr.Alias,


### PR DESCRIPTION
Make json of getNeighbors always the same number of attributes (21).

<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to this repository, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up to smaller PRs. This will help getting it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split to several PRs!!!!!
-->

# Description
An external Peer manager should always get the same json-fields for a peer, The connected/unconnected or manually/autopeered state should not matter.

# Fix
Remove the ``omitempty`` options in the definition of Info.

## Type of change
- [x] Enhancement (non-breaking change which adds functionality)

# How Has This Been Tested?
Tested with my own HORNET node version 0.4.0-rc10-7511e71

# Checklist:
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my code extensively
- [x] I have selected the `develop` branch as the target branch
